### PR TITLE
Fix module naming error

### DIFF
--- a/src/pupil_labs/rec_export/explib/neon/__init__.py
+++ b/src/pupil_labs/rec_export/explib/neon/__init__.py
@@ -4,7 +4,7 @@ from typing import Generator, Union
 import numpy as np
 
 from pupil_labs.neon_recording.timeseries.imu import imu_pb2
-from pupil_labs.neon_recording.timeseries.imu.imu_stream import parse_neon_imu_raw_packets
+from pupil_labs.neon_recording.timeseries.imu.imu_timeseries import parse_neon_imu_raw_packets
 
 
 imu_dtype = np.dtype(


### PR DESCRIPTION
Following the API update in pl-neon-recording >=2.0, `stream` is now called `timeseries`. The module import should be updated accordingly otherwise triggering:
`ModuleNotFoundError: No module named 'pupil_labs.neon_recording.timeseries.imu.imu_stream'`